### PR TITLE
Use string instead of UUID for uuid in USN

### DIFF
--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/models/Constants.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/models/Constants.kt
@@ -26,7 +26,7 @@ object Constants {
     const val NOT_AVAILABLE = "N/A"
     const val NOT_AVAILABLE_NUM = -1
     const val NOT_AVAILABLE_CACHE = 1800
-    val NOT_AVAILABLE_UUID = UUID(0, 0)
+    val NOT_AVAILABLE_UUID = UUID(0, 0).toString()
     val NOT_AVAILABLE_LOCATION = URL("http://127.0.0.1/")
     val DEFAULT_MEDIA_HOST = MediaHost(InetAddress.getByName(DEFAULT_MULTICAST_ADDRESS), 1900)
 

--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/models/devices/MediaDevice.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/models/devices/MediaDevice.kt
@@ -23,7 +23,7 @@ abstract class MediaDevice
  * @param deviceList The list of devices (embedded AND root) present on this device
  */
 data class AbridgedMediaDevice(
-    val uuid: UUID,
+    val uuid: String,
     val host: MediaHost,
     val cache: Int,
     val bootId: Int?,

--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/models/packets/UniqueServiceName.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/models/packets/UniqueServiceName.kt
@@ -31,7 +31,6 @@ interface UniqueServiceName {
                 }
             val extraSegments = groups.getOrNull(1)?.split(":")
 
-
             // If a URN marker is present, chances are the USN is targeting the root device
             val isRootMessage = extraSegments == null || extraSegments.getOrNull(1) == "rootdevice"
             if (isRootMessage) {

--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/models/packets/UniqueServiceName.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/models/packets/UniqueServiceName.kt
@@ -9,7 +9,7 @@ import com.ivanempire.lighthouse.models.Constants.URN_MARKER
 /**
  * Wrapper class around an SSDP packet's USN field.
  */
-interface UniqueServiceName{
+interface UniqueServiceName {
     val uuid: String
     val bootId: Int
 

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/models/packets/UniqueServiceNameTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/models/packets/UniqueServiceNameTest.kt
@@ -1,0 +1,17 @@
+package com.ivanempire.lighthouse.models.packets
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Tests [UniqueServiceName] */
+class UniqueServiceNameTest {
+    @Test
+    fun `given USN for Amcrest camera correctly parses`() {
+        val usnString = "uuid:device_3_0-AMC066F0BC0A3747AF::urn:schemas-upnp-org:device:3.0-AMC066F0BC0A3747AF"
+        val usn = UniqueServiceName(usnString, 10)
+        assertEquals(
+            EmbeddedDevice("device_3_0-AMC066F0BC0A3747AF", 10, "3.0-AMC066F0BC0A3747AF", ""),
+            usn
+        )
+    }
+}

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/LighthouseStateTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/LighthouseStateTest.kt
@@ -29,7 +29,7 @@ class LighthouseStateTest {
 
     @Test
     fun `given ALIVE packet creates root device correctly`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
         val ALIVE_PACKET_1 = generateAlivePacket(RANDOM_UUID_1)
 
         val finalList = sut.parseMediaPacket(ALIVE_PACKET_1)
@@ -52,8 +52,8 @@ class LighthouseStateTest {
 
     @Test
     fun `given ALIVE packet adjusts embedded components correctly`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
-        val RANDOM_UUID_2 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
+        val RANDOM_UUID_2 = UUID.randomUUID().toString()
 
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1)
         val MEDIA_DEVICE_2 = generateMediaDevice(RANDOM_UUID_2)
@@ -74,7 +74,7 @@ class LighthouseStateTest {
 
     @Test
     fun `given UPDATE packet builds root device correctly`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
         val UPDATE_PACKET_1 = generateUpdatePacket(RANDOM_UUID_1, location = URL("http://127.0.0.1:9999/"), bootId = 200, configId = 300, secureLocation = URL("https://127.0.0.1:9999/"))
 
         val finalList = sut.parseMediaPacket(UPDATE_PACKET_1)
@@ -90,9 +90,9 @@ class LighthouseStateTest {
 
     @Test
     fun `given UPDATE packet correctly updates embedded components`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
-        val RANDOM_UUID_2 = UUID.randomUUID()
-        val RANDOM_UUID_3 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
+        val RANDOM_UUID_2 = UUID.randomUUID().toString()
+        val RANDOM_UUID_3 = UUID.randomUUID().toString()
 
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1)
         val MEDIA_DEVICE_2 = generateMediaDevice(
@@ -153,7 +153,7 @@ class LighthouseStateTest {
 
     @Test
     fun `given UPDATE packet creates embedded components correctly`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1)
         sut.setDeviceList(listOf(MEDIA_DEVICE_1))
 
@@ -172,9 +172,9 @@ class LighthouseStateTest {
 
     @Test
     fun `given BYEBYE packet removes root device correctly`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
-        val RANDOM_UUID_2 = UUID.randomUUID()
-        val RANDOM_UUID_3 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
+        val RANDOM_UUID_2 = UUID.randomUUID().toString()
+        val RANDOM_UUID_3 = UUID.randomUUID().toString()
 
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1)
 
@@ -205,11 +205,11 @@ class LighthouseStateTest {
 
     @Test
     fun `given BYEBYE packet removes embedded components correctly`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
-        val RANDOM_UUID_2 = UUID.randomUUID()
-        val RANDOM_UUID_3 = UUID.randomUUID()
-        val RANDOM_UUID_4 = UUID.randomUUID()
-        val RANDOM_UUID_5 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
+        val RANDOM_UUID_2 = UUID.randomUUID().toString()
+        val RANDOM_UUID_3 = UUID.randomUUID().toString()
+        val RANDOM_UUID_4 = UUID.randomUUID().toString()
+        val RANDOM_UUID_5 = UUID.randomUUID().toString()
 
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1)
         MEDIA_DEVICE_1.deviceList.add(generateUSN<EmbeddedDevice>(RANDOM_UUID_1) as EmbeddedDevice)
@@ -245,9 +245,9 @@ class LighthouseStateTest {
 
     @Test
     fun `given BYEBYE packet and no matching device does not remove anything`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
-        val RANDOM_UUID_2 = UUID.randomUUID()
-        val RANDOM_UUID_3 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
+        val RANDOM_UUID_2 = UUID.randomUUID().toString()
+        val RANDOM_UUID_3 = UUID.randomUUID().toString()
 
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1)
         val MEDIA_DEVICE_2 = generateMediaDevice(RANDOM_UUID_2)
@@ -262,8 +262,8 @@ class LighthouseStateTest {
 
     @Test
     fun `given no stale devices doesn't return anything`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
-        val RANDOM_UUID_2 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
+        val RANDOM_UUID_2 = UUID.randomUUID().toString()
 
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1, cache = 1900)
         val MEDIA_DEVICE_2 = generateMediaDevice(RANDOM_UUID_2, cache = 1900)
@@ -276,8 +276,8 @@ class LighthouseStateTest {
 
     @Test
     fun `given stale devices returns them`() {
-        val RANDOM_UUID_1 = UUID.randomUUID()
-        val RANDOM_UUID_2 = UUID.randomUUID()
+        val RANDOM_UUID_1 = UUID.randomUUID().toString()
+        val RANDOM_UUID_2 = UUID.randomUUID().toString()
 
         val MEDIA_DEVICE_1 = generateMediaDevice(RANDOM_UUID_1, cache = 30, latestTimestamp = System.currentTimeMillis() - 35 * 1000)
         val MEDIA_DEVICE_2 = generateMediaDevice(RANDOM_UUID_2, cache = 10, latestTimestamp = System.currentTimeMillis() - 25 * 1000)

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/TestUtils.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/TestUtils.kt
@@ -32,7 +32,7 @@ object TestUtils {
      * @return An instance of [AbridgedMediaDevice] to use during unit testing
      */
     fun generateMediaDevice(
-        deviceUUID: UUID? = null,
+        deviceUUID: String? = null,
         mediaHost: MediaHost? = null,
         embeddedDevices: MutableList<EmbeddedDevice>? = null,
         embeddedServices: MutableList<EmbeddedService>? = null,
@@ -40,7 +40,7 @@ object TestUtils {
         latestTimestamp: Long? = null
     ): AbridgedMediaDevice {
         return AbridgedMediaDevice(
-            uuid = deviceUUID ?: UUID.randomUUID(),
+            uuid = deviceUUID ?: UUID.randomUUID().toString(),
             host = mediaHost ?: MediaHost(InetAddress.getByName("239.255.255.250"), 1900),
             cache = cache ?: 0,
             bootId = (Math.random() * 1000).toInt(),
@@ -59,7 +59,7 @@ object TestUtils {
      * Generates an instance of [AliveMediaPacket]
      */
     internal fun generateAlivePacket(
-        deviceUUID: UUID,
+        deviceUUID: String,
         uniqueServiceName: UniqueServiceName? = null
     ): AliveMediaPacket {
         return AliveMediaPacket(
@@ -68,7 +68,7 @@ object TestUtils {
             location = URL("http://127.0.0.1:58122/"),
             notificationType = NotificationType("upnp:rootdevice"),
             server = SERVER_LIST.random(),
-            usn = uniqueServiceName ?: UniqueServiceName(deviceUUID.toString(), -1),
+            usn = uniqueServiceName ?: UniqueServiceName("uuid:$deviceUUID", -1),
             bootId = 100,
             configId = 130,
             searchPort = 1900,
@@ -80,7 +80,7 @@ object TestUtils {
      *
      */
     internal fun generateUpdatePacket(
-        deviceUUID: UUID,
+        deviceUUID: String,
         location: URL = URL("http://192.168.2.50:58121/"),
         uniqueServiceName: UniqueServiceName? = null,
         bootId: Int = 100,
@@ -91,7 +91,7 @@ object TestUtils {
             host = MediaHost(InetAddress.getByName("239.255.255.250"), 1900),
             location = location,
             notificationType = NotificationType("upnp:rootdevice"),
-            usn = uniqueServiceName ?: UniqueServiceName(deviceUUID.toString(), bootId),
+            usn = uniqueServiceName ?: UniqueServiceName("uuid:$deviceUUID", bootId),
             bootId = bootId,
             configId = configId,
             nextBootId = bootId + 1,
@@ -101,14 +101,14 @@ object TestUtils {
     }
 
     internal fun generateByeByePacket(
-        deviceUUID: UUID,
+        deviceUUID: String,
         uniqueServiceName: UniqueServiceName? = null,
         bootId: Int = 100,
     ): ByeByeMediaPacket {
         return ByeByeMediaPacket(
             host = MediaHost(InetAddress.getByName("239.255.255.250"), 1900),
             notificationType = NotificationType("upnp:rootdevice"),
-            usn = uniqueServiceName ?: UniqueServiceName(deviceUUID.toString(), bootId),
+            usn = uniqueServiceName ?: UniqueServiceName("uuid:$deviceUUID", bootId),
             bootId = bootId,
             configId = 110
         )
@@ -125,14 +125,14 @@ object TestUtils {
      * @return An instance of [UniqueServiceName] to use in unit testing
      */
     inline fun <reified T : UniqueServiceName> generateUSN(
-        deviceUUID: UUID,
+        deviceUUID: String,
         identifier: String = "RenderingControl",
         version: String = "3.0",
         bootId: Int = 600
     ): UniqueServiceName {
         return when (T::class) {
             RootDeviceInformation::class -> {
-                UniqueServiceName(deviceUUID.toString(), -1)
+                UniqueServiceName("uuid:$deviceUUID", -1)
             }
             EmbeddedDevice::class -> {
                 UniqueServiceName("uuid:$deviceUUID::urn:schemas-upnp-org:device:$identifier:$version", bootId)

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/AliveMediaPacketParserTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/AliveMediaPacketParserTest.kt
@@ -13,11 +13,10 @@ import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixt
 import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixtures.VALID_ALIVE_PACKET_HEADER_SET_1
 import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixtures.VALID_ALIVE_PACKET_HEADER_SET_2
 import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixtures.VALID_ALIVE_PACKET_HEADER_SET_3
-import java.net.InetAddress
-import java.net.URL
-import java.util.UUID
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.net.InetAddress
+import java.net.URL
 
 /** Tests [AliveMediaPacketParser] */
 class AliveMediaPacketParserTest {
@@ -54,7 +53,7 @@ class AliveMediaPacketParserTest {
         assertEquals(NotificationType("upnp:rootdevice"), parsedPacket.notificationType)
         assertEquals(
             RootDeviceInformation(
-                uuid = UUID.fromString("3f8744cd-30bf-4fc9-8a42-bad80ae660c1"),
+                uuid = "3f8744cd-30bf-4fc9-8a42-bad80ae660c1",
                 bootId = -1
             ),
             parsedPacket.usn
@@ -87,7 +86,7 @@ class AliveMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                uuid = UUID.fromString("b9783ad2-d548-9793-0eb9-42db373ade07"),
+                uuid = "b9783ad2-d548-9793-0eb9-42db373ade07",
                 bootId = 11,
                 serviceType = "RenderingControl",
                 serviceVersion = "1"
@@ -122,7 +121,7 @@ class AliveMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                uuid = UUID.fromString("3f8744cd-30bf-4fc9-8a42-bad80ae660c1"),
+                uuid = "3f8744cd-30bf-4fc9-8a42-bad80ae660c1",
                 bootId = 156,
                 serviceType = "SwitchPower",
                 serviceVersion = "1"
@@ -154,7 +153,7 @@ class AliveMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                uuid = UUID.fromString("3f8744cd-30bf-4fc9-8a42-bad80ae660c1"),
+                uuid = "3f8744cd-30bf-4fc9-8a42-bad80ae660c1",
                 bootId = 5,
                 serviceType = "Dimming",
                 serviceVersion = "1"

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/AliveMediaPacketParserTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/AliveMediaPacketParserTest.kt
@@ -13,10 +13,10 @@ import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixt
 import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixtures.VALID_ALIVE_PACKET_HEADER_SET_1
 import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixtures.VALID_ALIVE_PACKET_HEADER_SET_2
 import com.ivanempire.lighthouse.parsers.packets.AliveMediaPacketParserTest.Fixtures.VALID_ALIVE_PACKET_HEADER_SET_3
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import java.net.InetAddress
 import java.net.URL
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 /** Tests [AliveMediaPacketParser] */
 class AliveMediaPacketParserTest {

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/ByeByeMediaPacketParserTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/ByeByeMediaPacketParserTest.kt
@@ -13,10 +13,9 @@ import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fix
 import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fixtures.VALID_BYEBYE_PACKET_HEADER_SET_1
 import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fixtures.VALID_BYEBYE_PACKET_HEADER_SET_2
 import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fixtures.VALID_BYEBYE_PACKET_HEADER_SET_3
-import java.net.InetAddress
-import java.util.UUID
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.net.InetAddress
 
 /** Tests [ByeByeMediaPacketParser] */
 class ByeByeMediaPacketParserTest {
@@ -47,7 +46,7 @@ class ByeByeMediaPacketParserTest {
         )
         assertEquals(
             RootDeviceInformation(
-                uuid = UUID.fromString("3f8744cd-30bf-4fc9-8a42-bad80ae660c1"),
+                uuid = "3f8744cd-30bf-4fc9-8a42-bad80ae660c1",
                 bootId = 100,
             ),
             parsedPacket.usn
@@ -69,7 +68,7 @@ class ByeByeMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedDevice(
-                uuid = UUID.fromString("00000000-0000-0000-0200-00125A8A0960"),
+                uuid = "00000000-0000-0000-0200-00125A8A0960",
                 bootId = 200,
                 deviceType = "presence",
                 deviceVersion = "1",
@@ -94,7 +93,7 @@ class ByeByeMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                uuid = UUID.fromString("9ab0c000-f668-11de-9976-00a0ded0e859"),
+                uuid = "9ab0c000-f668-11de-9976-00a0ded0e859",
                 bootId = 4,
                 serviceType = "RenderingControl",
                 serviceVersion = "1"
@@ -118,7 +117,7 @@ class ByeByeMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                uuid = UUID.fromString("00000000-0000-0000-0000-000000000000"),
+                uuid = "00000000-0000-0000-0000-000000000000",
                 bootId = 9,
                 serviceType = "SwitchPower",
                 serviceVersion = "1"

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/ByeByeMediaPacketParserTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/ByeByeMediaPacketParserTest.kt
@@ -13,9 +13,9 @@ import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fix
 import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fixtures.VALID_BYEBYE_PACKET_HEADER_SET_1
 import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fixtures.VALID_BYEBYE_PACKET_HEADER_SET_2
 import com.ivanempire.lighthouse.parsers.packets.ByeByeMediaPacketParserTest.Fixtures.VALID_BYEBYE_PACKET_HEADER_SET_3
+import java.net.InetAddress
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import java.net.InetAddress
 
 /** Tests [ByeByeMediaPacketParser] */
 class ByeByeMediaPacketParserTest {

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/UpdateMediaPacketParserTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/UpdateMediaPacketParserTest.kt
@@ -11,11 +11,10 @@ import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fix
 import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fixtures.VALID_UPDATE_PACKET_HEADER_SET_1
 import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fixtures.VALID_UPDATE_PACKET_HEADER_SET_2
 import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fixtures.VALID_UPDATE_PACKET_HEADER_SET_3
-import java.net.InetAddress
-import java.net.URL
-import java.util.UUID
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.net.InetAddress
+import java.net.URL
 
 /** Tests [UpdateMediaPacketParser] */
 class UpdateMediaPacketParserTest {
@@ -52,7 +51,7 @@ class UpdateMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                UUID.fromString("b9783ad2-d548-9793-0eb9-42db373ade07"),
+                "b9783ad2-d548-9793-0eb9-42db373ade07",
                 100,
                 "SwitchPower",
                 "1"
@@ -80,7 +79,7 @@ class UpdateMediaPacketParserTest {
         assertEquals(NotificationSubtype.UPDATE, parsedPacket.notificationSubtype)
         assertEquals(
             EmbeddedService(
-                UUID.fromString("3ddcd1d3-2380-45f5-b069-2c4d54008cf2"),
+                "3ddcd1d3-2380-45f5-b069-2c4d54008cf2",
                 1525511561,
                 "WANPPPConnection",
                 "1"
@@ -112,7 +111,7 @@ class UpdateMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                UUID.fromString("b9783ad2-d548-9793-0eb9-42db373ade07"),
+                "b9783ad2-d548-9793-0eb9-42db373ade07",
                 -1,
                 "RenderingControl",
                 "1"
@@ -140,7 +139,7 @@ class UpdateMediaPacketParserTest {
         )
         assertEquals(
             EmbeddedService(
-                UUID.fromString("3f8744cd-30bf-4fc9-8a42-bad80ae660c1"),
+                "3f8744cd-30bf-4fc9-8a42-bad80ae660c1",
                 50,
                 "Dimming",
                 "1"

--- a/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/UpdateMediaPacketParserTest.kt
+++ b/lighthouse/src/test/java/com/ivanempire/lighthouse/parsers/packets/UpdateMediaPacketParserTest.kt
@@ -11,10 +11,10 @@ import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fix
 import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fixtures.VALID_UPDATE_PACKET_HEADER_SET_1
 import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fixtures.VALID_UPDATE_PACKET_HEADER_SET_2
 import com.ivanempire.lighthouse.parsers.packets.UpdateMediaPacketParserTest.Fixtures.VALID_UPDATE_PACKET_HEADER_SET_3
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import java.net.InetAddress
 import java.net.URL
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 /** Tests [UpdateMediaPacketParser] */
 class UpdateMediaPacketParserTest {


### PR DESCRIPTION
Devices supporting UPnP 1.0 are not guaranteed to give a valid UUID

This fixes issue #4