### PR TITLE
Update deviceList when receiving alive and update notifications

### DIFF
--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/core/LighthouseState.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/core/LighthouseState.kt
@@ -80,8 +80,10 @@ internal class LighthouseState {
             deviceList.add(baseDevice)
         } else {
             // Update the existing device
+            deviceList.remove(targetDevice)
             targetDevice = targetDevice.copy(latestTimestamp = System.currentTimeMillis())
             targetDevice.updateEmbeddedComponent(targetComponent)
+            deviceList.add(targetDevice)
         }
         targetDevice?.extraHeaders?.putAll(latestPacket.extraHeaders)
         return deviceList
@@ -116,23 +118,23 @@ internal class LighthouseState {
             baseDevice.updateEmbeddedComponent(targetComponent)
             deviceList.add(baseDevice)
         } else {
+            deviceList.remove(targetDevice)
             targetDevice = targetDevice.copy(latestTimestamp = System.currentTimeMillis())
             when (targetComponent) {
                 // ALIVE came first, UPDATE for root should only update certain fields
                 // cache and server are not affected
                 is RootDeviceInformation -> {
-                    val updatedDevice = targetDevice.copy(
+                    targetDevice = targetDevice.copy(
                         bootId = latestPacket.bootId,
                         configId = latestPacket.configId,
                         searchPort = latestPacket.searchPort,
                         location = latestPacket.location,
                         secureLocation = latestPacket.secureLocation,
                     )
-                    deviceList.remove(targetDevice)
-                    deviceList.add(updatedDevice)
                 }
                 else -> targetDevice.updateEmbeddedComponent(targetComponent)
             }
+            deviceList.add(targetDevice)
         }
         targetDevice?.extraHeaders?.putAll(latestPacket.extraHeaders)
         return deviceList


### PR DESCRIPTION
This fixes issue #8.

`extraHeaders` are not added when the device is not already in the list. I don't know if this is intentional.