### PR TITLE
disable loopback mode

### DIFF
--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/socket/RealSocketListener.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/socket/RealSocketListener.kt
@@ -36,7 +36,7 @@ internal class RealSocketListener(
         val multicastSocket = MulticastSocket(null)
         multicastSocket.reuseAddress = true
         multicastSocket.broadcast = true
-        multicastSocket.loopbackMode = false
+        multicastSocket.loopbackMode = true // disable LoopbackMode
 
         try {
             multicastSocket.joinGroup(multicastGroup)


### PR DESCRIPTION
I think this is a straight-forward fix. We aren't interested in receiving our own packets. The Java API method is terribly named. `true` disables the loopback. https://docs.oracle.com/javase/8/docs/api/java/net/MulticastSocket.html#setLoopbackMode-boolean-

Fixes #15