### PR TITLE
Implementing lock mechanism for `discoverDevices()`

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -20,8 +20,8 @@ dependencies {
     implementation(libs.compose.activity)
 
     // Switch out for local development
-    // implementation(project(":lighthouse"))
+    implementation(project(":lighthouse"))
 
     // Always points to latest release
-    implementation("com.ivanempire:lighthouse:2.1.1")
+    // implementation("com.ivanempire:lighthouse:2.1.1")
 }

--- a/demo/src/main/java/com/ivanempire/lighthouse/demo/MainActivity.kt
+++ b/demo/src/main/java/com/ivanempire/lighthouse/demo/MainActivity.kt
@@ -4,12 +4,16 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,11 +23,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.ivanempire.lighthouse.LighthouseClient
 import com.ivanempire.lighthouse.LighthouseLogger
 import com.ivanempire.lighthouse.models.devices.AbridgedMediaDevice
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.map
 
 class MainActivity : ComponentActivity() {
 
@@ -51,25 +55,48 @@ class MainActivity : ComponentActivity() {
             }
         }
 
+        // Setup the client
         lighthouseClient = LighthouseClient
             .Builder(this)
             .setLogger(customLogger)
             .setRetryCount(2)
             .build()
 
-        val devicesFlow = lighthouseClient.discoverDevices()
-            .map { devices -> devices.sortedBy { it.uuid } }
+        // Skips the need for Dagger in a simple demo app
+        val viewModelFactory = MainActivityViewModelFactory(lighthouseClient)
+        val viewModel = viewModelFactory.create(MainActivityViewModel::class.java)
 
         setContent {
-            val devices = devicesFlow.collectAsState(emptyList())
+            val discoveredDeviceList = viewModel.discoveredDevices.collectAsState()
 
-            Surface(modifier = Modifier.fillMaxSize()) {
-                LazyColumn {
+            Column(modifier = Modifier.padding(16.dp)) {
+                LazyColumn(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                ) {
                     items(
-                        items = devices.value,
+                        items = discoveredDeviceList.value,
                         key = { it.uuid },
                     ) {
-                        DeviceListItem(it)
+                        DeviceListItem(device = it)
+                    }
+                }
+
+                val isDiscoveryRunning = remember { mutableStateOf(false) }
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+                    Button(onClick = {
+                        viewModel.stopDiscovery()
+                        isDiscoveryRunning.value = false
+                    }, enabled = !isDiscoveryRunning.value) {
+                        Text(text = "Stop discovery")
+                    }
+                    Button(onClick = {
+                        viewModel.startDiscovery()
+                        isDiscoveryRunning.value = true
+                    }, enabled = !isDiscoveryRunning.value) {
+                        Text(text = "Start discovery")
                     }
                 }
             }

--- a/demo/src/main/java/com/ivanempire/lighthouse/demo/MainActivityViewModel.kt
+++ b/demo/src/main/java/com/ivanempire/lighthouse/demo/MainActivityViewModel.kt
@@ -1,0 +1,34 @@
+package com.ivanempire.lighthouse.demo
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ivanempire.lighthouse.LighthouseClient
+import com.ivanempire.lighthouse.models.devices.AbridgedMediaDevice
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+class MainActivityViewModel(
+    private val lighthouseClient: LighthouseClient,
+) : ViewModel() {
+
+    private var discoveryJob: Job? = null
+
+    private val backingDiscoveredDevices = MutableStateFlow<List<AbridgedMediaDevice>>(emptyList())
+    val discoveredDevices = backingDiscoveredDevices.asStateFlow()
+
+    fun startDiscovery() {
+        discoveryJob = viewModelScope.launch {
+            lighthouseClient.discoverDevices().collect {
+                backingDiscoveredDevices.value = it
+            }
+        }
+    }
+
+    fun stopDiscovery() = runBlocking {
+        discoveryJob?.cancelAndJoin()
+    }
+}

--- a/demo/src/main/java/com/ivanempire/lighthouse/demo/MainActivityViewModelFactory.kt
+++ b/demo/src/main/java/com/ivanempire/lighthouse/demo/MainActivityViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.ivanempire.lighthouse.demo
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.ivanempire.lighthouse.LighthouseClient
+
+class MainActivityViewModelFactory(private val lighthouseClient: LighthouseClient) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(
+        modelClass: Class<T>,
+    ): T {
+        return MainActivityViewModel(
+            lighthouseClient,
+        ) as T
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-gradle = "8.2.0"
+gradle = "8.2.2"
 maven = "0.26.0"
 junit = "4.13.2"
 kotlin = "1.8.10"
 mockito-core = "5.7.0"
-runtime = "2.6.2"
+runtime = "2.7.0"
 compose = "1.8.2"
 androidx = "1.12.0"
 coroutines = "1.7.3"
-compose-bom = "2023.10.01"
+compose-bom = "2024.01.00"
 
 [libraries]
 # Core Gradle dependencies
@@ -32,4 +32,4 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-cor
 testing-junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
-ktlint = "org.jlleitschuh.gradle.ktlint:11.6.1"
+ktlint = "org.jlleitschuh.gradle.ktlint:12.1.0"

--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/LighthouseClient.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/LighthouseClient.kt
@@ -67,5 +67,5 @@ interface LighthouseClient {
      * @param searchRequest The [SearchRequest] to send to the multicast group to discover devices
      * @return Flow of lists of [AbridgedMediaDevice] that have been discovered on the network
      */
-    fun discoverDevices(searchRequest: SearchRequest = DEFAULT_SEARCH_REQUEST): Flow<List<AbridgedMediaDevice>>
+    suspend fun discoverDevices(searchRequest: SearchRequest = DEFAULT_SEARCH_REQUEST): Flow<List<AbridgedMediaDevice>>
 }

--- a/lighthouse/src/main/java/com/ivanempire/lighthouse/core/RealLighthouseClient.kt
+++ b/lighthouse/src/main/java/com/ivanempire/lighthouse/core/RealLighthouseClient.kt
@@ -10,6 +10,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /** Specific implementation of [LighthouseClient] */
 internal class RealLighthouseClient(
@@ -18,7 +21,17 @@ internal class RealLighthouseClient(
     private val logger: LighthouseLogger? = null,
 ) : LighthouseClient {
 
-    override fun discoverDevices(searchRequest: SearchRequest): Flow<List<AbridgedMediaDevice>> {
+    private val discoveryMutex = Mutex()
+    private var isDiscoveryRunning = false
+
+    override suspend fun discoverDevices(searchRequest: SearchRequest): Flow<List<AbridgedMediaDevice>> {
+        discoveryMutex.withLock {
+            if (isDiscoveryRunning) {
+                throw IllegalStateException("Discovery is already in progress - did you call discoverDevices() multiple times?")
+            }
+            isDiscoveryRunning = true
+        }
+
         logger?.logStatusMessage(TAG, "Discovering devices with search request: $searchRequest")
 
         val foundDevicesFlow = discoveryManager.createNewDeviceFlow(searchRequest)
@@ -27,6 +40,11 @@ internal class RealLighthouseClient(
         return merge(foundDevicesFlow, lostDevicesFlow)
             .distinctUntilChanged()
             .flowOn(dispatcher)
+            .onCompletion {
+                discoveryMutex.withLock {
+                    isDiscoveryRunning = false
+                }
+            }
     }
 
     private companion object {


### PR DESCRIPTION
## Description
This PR addresses #27 where one would be able to call `discoverDevices()` multiple times. Only one call is allowed and there's an explicit locking mechanism + exception and error message thrown. There are some QoL improvements in the demo app, and a breaking API change since `discoverDevices()` is now a suspending function, meaning the next release will be a major one. Some dependencies have been updated as well.